### PR TITLE
#3 bugfix - fix carousel not reset properly when items prop is updated

### DIFF
--- a/src/components/CatCarousel.vue
+++ b/src/components/CatCarousel.vue
@@ -127,8 +127,13 @@
     },
     watch: {
       items () {
+        this.wrapper = {
+          translateX: 0
+        }
+        this.track = 0
         this.maxSlide = Math.ceil(this.items.length / this.itemPerPage)
         this.itemWidth = this.carouselItem.length > 0 && this.carouselItem[0].clientWidth
+        this.initSlides()
       }
     },
     computed: {


### PR DESCRIPTION
Fix for issue #3 
Basically translate and track data need to be reset when items prop is updated.
I test this fix by changing items prop through a button and verify if carousel still work correctly,
here's a video 

[testing-video.zip](https://github.com/hanssagita/vue-components-collection/files/4820534/testing-video.zip)

