### PR TITLE
Release/1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-components-collection",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "vue-components-collection is a toolkit component library",
   "author": "Hans Sagita < hans.sagita@gmail.com >",
   "repository": {


### PR DESCRIPTION
# Overview

Added 2 new features

* Absolute carousel width
Using new `width` prop, carousel will have absolute width instead of adjusting to parent. Previously, the carousel container is set to 100% of parent width. Carousel item width will now be calculated based on `width` and `item-per-page` prop if this is prop is set.

* Initial carousel slide
Using new `initial-slide-index` prop, we can set the initial slide when loading the carousel.
To enable this feature, carousel need to have absolute width for style calculation on created hook. Without fixed width, it won't be possible to calculate on created hook since we would need images to load to get the width (most of carousel use cases are images).
Thus, `width` prop is **required** for this feature
